### PR TITLE
Updated script.js token creation

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -83,8 +83,8 @@ const requestForceAvailability = function () {
 
 		if (isEnabled || isEnabled === undefined) {
 			try {
-				const latestOid = localStorage["ts.latestOid"];
-				const tokenJSON = localStorage["ts." + latestOid + ".cache.token.https://presence.teams.microsoft.com/"];
+				const openDbs = localStorage['ts.openDbs'].split('"')[1].replace("skypexspaces-teams-offline-actions-storage-","");
+				const tokenJSON = localStorage["ts." + openDbs + ".cache.token.https://presence.teams.microsoft.com/"];
 				const token = JSON.parse(tokenJSON).token;
 
 				const response = await fetch("https://presence.teams.microsoft.com/v1/me/forceavailability/", {


### PR DESCRIPTION
Latest teams update removed "latestOid" from the ts.x.cahce field. Workaround was to pull the new id from a ts.openDbs field, remove irrelevant text and use it in place of where latestOid was in token creation.

I'm not sure if the openDbs field will list different fields based on the what a company has or has not subscribed to for the enterprise, however this (removing "skypexspaces-teams-offline-actions-storage-" from the id) is what is working for my setup.

Obviously if openDbs changed then this will break again, I was not able to identify a field in local storage that stores the id without requiring parsing. 